### PR TITLE
feat: support oidc provider

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/traefik/ingress-nginx-migration/pkg/logger"
 	"github.com/urfave/cli/v3"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
Hello,

Work on my kubernetes cluster with oidc connection.

The blank import _ "k8s.io/client-go/plugin/pkg/client/auth" registers all the authentication
plugins that client-go supports:

- OIDC - OpenID Connect authentication
- GCP - Google Cloud Platform authentication
- Azure - Azure Active Directory authentication
- exec - External command-based authentication

Thanks for this usefull tools !

Br