### PR TITLE
reorder supportedAnnotations and add rewrite-target, temporal-redirect, permanent-redirect and session-cookie-expires

### DIFF
--- a/pkg/analyzer/report.go
+++ b/pkg/analyzer/report.go
@@ -54,7 +54,7 @@ var supportedAnnotations = map[string]struct{}{
 	"nginx.ingress.kubernetes.io/ssl-passthrough":         {},
 	"nginx.ingress.kubernetes.io/ssl-redirect":            {},
 	"nginx.ingress.kubernetes.io/temporal-redirect":       {},
-	"nginx.ingress.kubernetes.io/temporal-redirect-code":v {},
+	"nginx.ingress.kubernetes.io/temporal-redirect-code":  {},
 	"nginx.ingress.kubernetes.io/use-regex":               {},
 }
 


### PR DESCRIPTION
This PR just reorders the supportedAnnotations so they are in alphabetical order and also adds the extra annotations PR'd by @LBF38 to the list. Example PR: https://github.com/traefik/traefik/pull/12534. I will understand if you do not want to merge the PR until the commit https://github.com/traefik/traefik/commit/dc6d54532d57315e111093600c5a75ec2a594526 is included in a tagged Traefik release.