### PR TITLE
Add new TLS e2e tests

### DIFF
--- a/e2e/base_suite_test.go
+++ b/e2e/base_suite_test.go
@@ -323,15 +323,21 @@ func renderTraefikHelmChart(image string) (string, error) {
 	return tmpFile.Name(), nil
 }
 
+type ingressDefaultBackend struct {
+	ServiceName string
+	ServicePort int
+}
+
 type ingressTemplateData struct {
-	Name        string
-	Host        string
-	Path        string
-	PathType    string
-	Annotations map[string]string
-	ServiceName string // default: "backend"
-	ServicePort int    // default: 80
-	TLSSecret   string // if non-empty, adds spec.tls section
+	Name           string
+	Host           string
+	Path           string
+	PathType       string
+	Annotations    map[string]string
+	DefaultBackend *ingressDefaultBackend
+	ServiceName    string // default: "backend"
+	ServicePort    int    // default: 80
+	TLSSecret      string // if non-empty, adds spec.tls section
 }
 
 type nginxBackendTemplateData struct {

--- a/e2e/fixtures/ingress.yaml.tmpl
+++ b/e2e/fixtures/ingress.yaml.tmpl
@@ -13,6 +13,13 @@ metadata:
 {{- end }}
 spec:
   ingressClassName: nginx
+{{- if .DefaultBackend }}
+  defaultBackend:
+    service:
+      name: {{ .DefaultBackend.ServiceName }}
+      port:
+        number: {{ .DefaultBackend.ServicePort }}
+{{- end }}
 {{- if .TLSSecret }}
   tls:
   - hosts:

--- a/e2e/tls_suite_test.go
+++ b/e2e/tls_suite_test.go
@@ -31,10 +31,11 @@ func (s *TLSSuite) TearDownSuite() {
 
 func (s *TLSSuite) TestTLS() {
 	testCases := []struct {
-		desc        string
-		annotations map[string]string
-		tlsSecret   string
-		test        func(t *testing.T, hostTraefik, hostNginx string)
+		desc           string
+		annotations    map[string]string
+		tlsSecret      string
+		defaultBackend *ingressDefaultBackend
+		test           func(t *testing.T, hostTraefik, hostNginx string)
 	}{
 		{
 			desc:        "no .spec.tls section",
@@ -69,6 +70,65 @@ func (s *TLSSuite) TestTLS() {
 				assert.Equal(t, http.StatusOK, nginxResp.StatusCode, "nginx status code mismatch")
 			},
 		},
+		{
+			desc: "invalid tls secret - with force-ssl-redirect",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+			},
+			tlsSecret: "invalid-secret",
+			test: func(t *testing.T, hostTraefik, hostNginx string) {
+				t.Helper()
+
+				traefikResp := s.traefik.MakeTLSRequest(t, hostTraefik, http.MethodGet, "/resource", nil, nil, 3, 1*time.Second)
+				require.NotNil(t, traefikResp, "traefik response should not be nil")
+
+				nginxResp := s.nginx.MakeTLSRequest(t, hostNginx, http.MethodGet, "/resource", nil, nil, 3, 1*time.Second)
+				require.NotNil(t, nginxResp, "nginx response should not be nil")
+
+				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "traefik status code mismatch")
+				assert.Equal(t, http.StatusOK, nginxResp.StatusCode, "nginx status code mismatch")
+
+				traefikResp = s.traefik.MakeRequest(t, hostTraefik, http.MethodGet, "/resource", nil, 3, 1*time.Second)
+				require.NotNil(t, traefikResp, "traefik response should not be nil")
+
+				nginxResp = s.nginx.MakeRequest(t, hostNginx, http.MethodGet, "/resource", nil, 3, 1*time.Second)
+				require.NotNil(t, nginxResp, "nginx response should not be nil")
+
+				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "traefik status code mismatch")
+				assert.Equal(t, http.StatusOK, nginxResp.StatusCode, "nginx status code mismatch")
+			},
+		},
+		{
+			desc:        "default backend",
+			annotations: map[string]string{},
+			defaultBackend: &ingressDefaultBackend{
+				ServiceName: "status-backend",
+				ServicePort: 80,
+			},
+			test: func(t *testing.T, hostTraefik, hostNginx string) {
+				t.Helper()
+
+				// HTTP
+				traefikResp := s.traefik.MakeRequest(t, hostTraefik, http.MethodGet, "/other", nil, 3, 1*time.Second)
+				require.NotNil(t, traefikResp, "traefik response should not be nil")
+
+				nginxResp := s.nginx.MakeRequest(t, hostNginx, http.MethodGet, "/other", nil, 3, 1*time.Second)
+				require.NotNil(t, nginxResp, "nginx response should not be nil")
+
+				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "traefik status code mismatch")
+				assert.Equal(t, http.StatusOK, nginxResp.StatusCode, "nginx status code mismatch")
+
+				// TLS
+				traefikResp = s.traefik.MakeTLSRequest(t, hostTraefik, http.MethodGet, "/", nil, nil, 3, 1*time.Second)
+				require.NotNil(t, traefikResp, "traefik response should not be nil")
+
+				nginxResp = s.nginx.MakeTLSRequest(t, hostNginx, http.MethodGet, "/", nil, nil, 3, 1*time.Second)
+				require.NotNil(t, nginxResp, "nginx response should not be nil")
+
+				assert.Equal(t, http.StatusPermanentRedirect, traefikResp.StatusCode, "traefik status code mismatch")
+				assert.Equal(t, http.StatusPermanentRedirect, nginxResp.StatusCode, "nginx status code mismatch")
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -78,19 +138,35 @@ func (s *TLSSuite) TestTLS() {
 			hostTraefik := prefix + ".traefik.local"
 			hostNginx := prefix + ".nginx.local"
 
+			if test.defaultBackend != nil {
+				// Deploy status-backend and error-backend to both clusters.
+				for _, cluster := range []*Cluster{s.traefik, s.nginx} {
+					err := cluster.ApplyFixture("status-backend.yaml")
+					require.NoError(s.T(), err, "deploy status-backend to %s cluster", cluster.Name)
+				}
+
+				// Wait for backends to be ready.
+				for _, cluster := range []*Cluster{s.traefik, s.nginx} {
+					err := waitForDeployment(cluster, cluster.TestNamespace, "status-backend")
+					require.NoError(s.T(), err, "status-backend not ready in %s cluster", cluster.Name)
+				}
+			}
+
 			err := s.traefik.DeployIngressWith(ingressTemplateData{
-				Name:        prefix,
-				Host:        hostTraefik,
-				Annotations: test.annotations,
-				TLSSecret:   test.tlsSecret,
+				Name:           prefix,
+				Host:           hostTraefik,
+				Annotations:    test.annotations,
+				TLSSecret:      test.tlsSecret,
+				DefaultBackend: test.defaultBackend,
 			})
 			require.NoError(s.T(), err, "deploy %s ingress to traefik cluster", prefix)
 
 			err = s.nginx.DeployIngressWith(ingressTemplateData{
-				Name:        prefix,
-				Host:        hostNginx,
-				Annotations: test.annotations,
-				TLSSecret:   test.tlsSecret,
+				Name:           prefix,
+				Host:           hostNginx,
+				Annotations:    test.annotations,
+				TLSSecret:      test.tlsSecret,
+				DefaultBackend: test.defaultBackend,
 			})
 			require.NoError(s.T(), err, "deploy %s ingress to nginx cluster", prefix)
 


### PR DESCRIPTION
Update TLS tests with new e2e cases related to recent issues on ingress-nginx provider.