### PR TITLE
Add more tests for app-root annotation

### DIFF
--- a/e2e/approot_suite_test.go
+++ b/e2e/approot_suite_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -72,15 +71,16 @@ func (s *AppRootSuite) TestAppRoot() {
 			method: http.MethodGet,
 			path:   "/",
 			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				t.Helper()
 				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 				assert.Equal(t, http.StatusFound, traefikResp.StatusCode, "expected redirect for /")
 
 				traefikLocation := traefikResp.ResponseHeaders.Get("Location")
 				nginxLocation := nginxResp.ResponseHeaders.Get("Location")
 
-				assert.True(t, strings.HasSuffix(traefikLocation, "/dashboard"),
+				assert.Equal(t, "http://"+appRootTraefikHost+"/dashboard", traefikLocation,
 					"traefik Location header should end with /dashboard, got: %s", traefikLocation)
-				assert.True(t, strings.HasSuffix(nginxLocation, "/dashboard"),
+				assert.Equal(t, "http://"+appRootNginxHost+"/dashboard", nginxLocation,
 					"nginx Location header should end with /dashboard, got: %s", nginxLocation)
 			},
 		},
@@ -89,6 +89,7 @@ func (s *AppRootSuite) TestAppRoot() {
 			method: http.MethodGet,
 			path:   "/other",
 			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				t.Helper()
 				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "expected 200 for non-root path /other")
 
@@ -101,8 +102,45 @@ func (s *AppRootSuite) TestAppRoot() {
 			method: http.MethodGet,
 			path:   "/some/path/",
 			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				t.Helper()
 				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "expected 200 for /some/path/")
+			},
+		},
+		{
+			desc:   "root with query parameter",
+			method: http.MethodGet,
+			path:   "/?foo=bar",
+			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				t.Helper()
+				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+				assert.Equal(t, http.StatusFound, traefikResp.StatusCode, "expected redirect for /?foo=bar")
+
+				traefikLocation := traefikResp.ResponseHeaders.Get("Location")
+				nginxLocation := nginxResp.ResponseHeaders.Get("Location")
+
+				assert.Equal(t, "http://"+appRootTraefikHost+"/dashboard", traefikLocation,
+					"traefik Location header should end with /dashboard, got: %s", traefikLocation)
+				assert.Equal(t, "http://"+appRootNginxHost+"/dashboard", nginxLocation,
+					"nginx Location header should end with /dashboard, got: %s", nginxLocation)
+			},
+		},
+		{
+			desc:   "root with multiple query parameters",
+			method: http.MethodGet,
+			path:   "/?foo=bar&baz=qux",
+			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				t.Helper()
+				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+				assert.Equal(t, http.StatusFound, traefikResp.StatusCode, "expected redirect for /?foo=bar&baz=qux")
+
+				traefikLocation := traefikResp.ResponseHeaders.Get("Location")
+				nginxLocation := nginxResp.ResponseHeaders.Get("Location")
+
+				assert.Equal(t, "http://"+appRootTraefikHost+"/dashboard", traefikLocation,
+					"traefik Location header should end with /dashboard, got: %s", traefikLocation)
+				assert.Equal(t, "http://"+appRootNginxHost+"/dashboard", nginxLocation,
+					"nginx Location header should end with /dashboard, got: %s", nginxLocation)
 			},
 		},
 	}

--- a/e2e/approot_suite_test.go
+++ b/e2e/approot_suite_test.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	appRootIngressName = "app-root-test"
+	appRootTraefikHost = appRootIngressName + ".traefik.local"
+	appRootNginxHost   = appRootIngressName + ".nginx.local"
+)
+
+type AppRootSuite struct {
+	BaseSuite
+}
+
+func TestAppRootSuite(t *testing.T) {
+	suite.Run(t, new(AppRootSuite))
+}
+
+func (s *AppRootSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+
+	appRootAnnotations := map[string]string{
+		"nginx.ingress.kubernetes.io/app-root": "/dashboard",
+	}
+
+	err := s.traefik.DeployIngress(appRootIngressName, appRootTraefikHost, appRootAnnotations)
+	require.NoError(s.T(), err, "deploy app-root ingress to traefik cluster")
+
+	err = s.nginx.DeployIngress(appRootIngressName, appRootNginxHost, appRootAnnotations)
+	require.NoError(s.T(), err, "deploy app-root ingress to nginx cluster")
+
+	s.traefik.WaitForIngressReady(s.T(), appRootTraefikHost, 20, 1*time.Second)
+	s.nginx.WaitForIngressReady(s.T(), appRootNginxHost, 20, 1*time.Second)
+}
+
+func (s *AppRootSuite) TearDownSuite() {
+	_ = s.traefik.DeleteIngress(appRootIngressName)
+	_ = s.nginx.DeleteIngress(appRootIngressName)
+}
+
+func (s *AppRootSuite) request(method, path string, headers map[string]string) (traefikResp, nginxResp *Response) {
+	s.T().Helper()
+
+	traefikResp = s.traefik.MakeRequest(s.T(), appRootTraefikHost, method, path, headers, 3, 1*time.Second)
+	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
+
+	nginxResp = s.nginx.MakeRequest(s.T(), appRootNginxHost, method, path, headers, 3, 1*time.Second)
+	require.NotNil(s.T(), nginxResp, "nginx response should not be nil")
+
+	return traefikResp, nginxResp
+}
+
+func (s *AppRootSuite) TestAppRoot() {
+	testCases := []struct {
+		desc    string
+		method  string
+		path    string
+		headers map[string]string
+		check   func(t *testing.T, traefikResp, nginxResp *Response)
+	}{
+		{
+			desc:   "root redirects to app-root",
+			method: http.MethodGet,
+			path:   "/",
+			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+				assert.Equal(t, http.StatusFound, traefikResp.StatusCode, "expected redirect for /")
+
+				traefikLocation := traefikResp.ResponseHeaders.Get("Location")
+				nginxLocation := nginxResp.ResponseHeaders.Get("Location")
+
+				assert.True(t, strings.HasSuffix(traefikLocation, "/dashboard"),
+					"traefik Location header should end with /dashboard, got: %s", traefikLocation)
+				assert.True(t, strings.HasSuffix(nginxLocation, "/dashboard"),
+					"nginx Location header should end with /dashboard, got: %s", nginxLocation)
+			},
+		},
+		{
+			desc:   "non-root path passthrough",
+			method: http.MethodGet,
+			path:   "/other",
+			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "expected 200 for non-root path /other")
+
+				traefikLocation := traefikResp.ResponseHeaders.Get("Location")
+				assert.Equal(t, "", traefikLocation, "no redirect for non-root path")
+			},
+		},
+		{
+			desc:   "non-root path with trailing slash",
+			method: http.MethodGet,
+			path:   "/some/path/",
+			check: func(t *testing.T, traefikResp, nginxResp *Response) {
+				assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+				assert.Equal(t, http.StatusOK, traefikResp.StatusCode, "expected 200 for /some/path/")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			traefikResp, nginxResp := s.request(tc.method, tc.path, tc.headers)
+			tc.check(t, traefikResp, nginxResp)
+		})
+	}
+}

--- a/e2e/approot_suite_test.go
+++ b/e2e/approot_suite_test.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +46,18 @@ func (s *AppRootSuite) SetupSuite() {
 func (s *AppRootSuite) TearDownSuite() {
 	_ = s.traefik.DeleteIngress(appRootIngressName)
 	_ = s.nginx.DeleteIngress(appRootIngressName)
+}
+
+func (s *AppRootSuite) requestWithHost(method, path string, headers map[string]string, host string) (traefikResp, nginxResp *Response) {
+	s.T().Helper()
+
+	traefikResp = s.traefik.MakeRequest(s.T(), host, method, path, headers, 3, 1*time.Second)
+	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
+
+	nginxResp = s.nginx.MakeRequest(s.T(), strings.Replace(host, "traefik.local", "nginx.local", 1), method, path, headers, 3, 1*time.Second)
+	require.NotNil(s.T(), nginxResp, "nginx response should not be nil")
+
+	return traefikResp, nginxResp
 }
 
 func (s *AppRootSuite) request(method, path string, headers map[string]string) (traefikResp, nginxResp *Response) {
@@ -149,6 +163,71 @@ func (s *AppRootSuite) TestAppRoot() {
 		s.T().Run(tc.desc, func(t *testing.T) {
 			traefikResp, nginxResp := s.request(tc.method, tc.path, tc.headers)
 			tc.check(t, traefikResp, nginxResp)
+		})
+	}
+}
+
+func (s *AppRootSuite) TestAppRootWithVariableInterpolation() {
+	const (
+		variableIngressName = "app-root-var"
+		variableTraefikHost = variableIngressName + ".traefik.local"
+		variableNginxHost   = variableIngressName + ".nginx.local"
+	)
+
+	variableAnnotations := map[string]string{
+		"nginx.ingress.kubernetes.io/app-root": "/login$is_args$args",
+	}
+
+	err := s.traefik.DeployIngress(variableIngressName, variableTraefikHost, variableAnnotations)
+	require.NoError(s.T(), err, "deploy variable app-root ingress to traefik cluster")
+
+	err = s.nginx.DeployIngress(variableIngressName, variableNginxHost, variableAnnotations)
+	require.NoError(s.T(), err, "deploy variable app-root ingress to nginx cluster")
+
+	s.T().Cleanup(func() {
+		_ = s.traefik.DeleteIngress(variableIngressName)
+		_ = s.nginx.DeleteIngress(variableIngressName)
+	})
+
+	s.traefik.WaitForIngressReady(s.T(), variableTraefikHost, 20, 1*time.Second)
+	s.nginx.WaitForIngressReady(s.T(), variableNginxHost, 20, 1*time.Second)
+
+	testCases := []struct {
+		desc     string
+		path     string
+		expected string
+	}{
+		{
+			desc:     "root without query params",
+			path:     "/",
+			expected: "/login",
+		},
+		{
+			desc:     "root with single query param",
+			path:     "/?foo=bar",
+			expected: "/login?foo=bar",
+		},
+		{
+			desc:     "root with multiple query params",
+			path:     "/?foo=bar&baz=qux",
+			expected: "/login?foo=bar&baz=qux",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			traefikResp, nginxResp := s.requestWithHost(http.MethodGet, tc.path, nil, variableTraefikHost)
+
+			assert.Equal(t, nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+			assert.Equal(t, http.StatusFound, traefikResp.StatusCode, "expected redirect for %s", tc.path)
+
+			traefikLocation := traefikResp.ResponseHeaders.Get("Location")
+			nginxLocation := nginxResp.ResponseHeaders.Get("Location")
+
+			assert.Equal(t, fmt.Sprintf("http://%s%s", variableTraefikHost, tc.expected), traefikLocation,
+				"traefik Location mismatch for %s", tc.path)
+			assert.Equal(t, fmt.Sprintf("http://%s%s", variableNginxHost, tc.expected), nginxLocation,
+				"nginx Location mismatch for %s", tc.path)
 		})
 	}
 }

--- a/e2e/rewritetarget_suite_test.go
+++ b/e2e/rewritetarget_suite_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,10 +17,6 @@ const (
 	rewriteNginxHost          = rewriteIngressName + ".nginx.local"
 	rewriteCaptureTraefikHost = rewriteCaptureIngressName + ".traefik.local"
 	rewriteCaptureNginxHost   = rewriteCaptureIngressName + ".nginx.local"
-
-	appRootIngressName = "app-root-test"
-	appRootTraefikHost = appRootIngressName + ".traefik.local"
-	appRootNginxHost   = appRootIngressName + ".nginx.local"
 
 	noRegexIngressName = "no-regex-test"
 	noRegexTraefikHost = noRegexIngressName + ".traefik.local"
@@ -99,17 +94,6 @@ func (s *RewriteTargetSuite) SetupSuite() {
 		PathType:    "ImplementationSpecific",
 	})
 	require.NoError(s.T(), err, "deploy capture group rewrite ingress to nginx cluster")
-
-	// App-root redirect ingress: / -> /dashboard
-	appRootAnnotations := map[string]string{
-		"nginx.ingress.kubernetes.io/app-root": "/dashboard",
-	}
-
-	err = s.traefik.DeployIngress(appRootIngressName, appRootTraefikHost, appRootAnnotations)
-	require.NoError(s.T(), err, "deploy app-root ingress to traefik cluster")
-
-	err = s.nginx.DeployIngress(appRootIngressName, appRootNginxHost, appRootAnnotations)
-	require.NoError(s.T(), err, "deploy app-root ingress to nginx cluster")
 
 	// No-regex ingress: rewrite-target is set but use-regex is "false",
 	// so the rewrite should NOT take effect.
@@ -193,8 +177,6 @@ func (s *RewriteTargetSuite) SetupSuite() {
 	s.waitForRewriteIngressReady(s.nginx, rewriteNginxHost, "/app")
 	s.waitForRewriteIngressReady(s.traefik, rewriteCaptureTraefikHost, "/api/healthz")
 	s.waitForRewriteIngressReady(s.nginx, rewriteCaptureNginxHost, "/api/healthz")
-	s.waitForRewriteIngressReady(s.traefik, appRootTraefikHost, "/dashboard")
-	s.waitForRewriteIngressReady(s.nginx, appRootNginxHost, "/dashboard")
 	s.waitForRewriteIngressReady(s.traefik, noRegexTraefikHost, "/")
 	s.waitForRewriteIngressReady(s.nginx, noRegexNginxHost, "/")
 	s.waitForRewriteIngressReady(s.traefik, exactPathTraefikHost, "/original")
@@ -224,8 +206,6 @@ func (s *RewriteTargetSuite) TearDownSuite() {
 	_ = s.nginx.DeleteIngress(rewriteIngressName)
 	_ = s.traefik.DeleteIngress(rewriteCaptureIngressName)
 	_ = s.nginx.DeleteIngress(rewriteCaptureIngressName)
-	_ = s.traefik.DeleteIngress(appRootIngressName)
-	_ = s.nginx.DeleteIngress(appRootIngressName)
 	_ = s.traefik.DeleteIngress(noRegexIngressName)
 	_ = s.nginx.DeleteIngress(noRegexIngressName)
 	_ = s.traefik.DeleteIngress(exactPathIngressName)
@@ -268,8 +248,8 @@ func (s *RewriteTargetSuite) TestSimpleRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /app")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET / HTTP/1.1", "nginx backend should see URI /")
-	assert.Contains(s.T(), traefikResp.Body, "GET / HTTP/1.1", "traefik backend should see URI /")
+	assert.Contains(s.T(), "GET / HTTP/1.1", nginxResp.Body, "nginx backend should see URI /")
+	assert.Contains(s.T(), "GET / HTTP/1.1", traefikResp.Body, "traefik backend should see URI /")
 }
 
 func (s *RewriteTargetSuite) TestSimpleRewriteSubpath() {
@@ -278,8 +258,8 @@ func (s *RewriteTargetSuite) TestSimpleRewriteSubpath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /app/hello")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET /hello HTTP/1.1", "nginx backend should see URI /hello")
-	assert.Contains(s.T(), traefikResp.Body, "GET /hello HTTP/1.1", "traefik backend should see URI /hello")
+	assert.Contains(s.T(), "GET /hello HTTP/1.1", nginxResp.Body, "nginx backend should see URI /hello")
+	assert.Contains(s.T(), "GET /hello HTTP/1.1", traefikResp.Body, "traefik backend should see URI /hello")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewrite() {
@@ -288,8 +268,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/users")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET /users HTTP/1.1", "nginx backend should see URI /users")
-	assert.Contains(s.T(), traefikResp.Body, "GET /users HTTP/1.1", "traefik backend should see URI /users")
+	assert.Contains(s.T(), "GET /users HTTP/1.1", nginxResp.Body, "nginx backend should see URI /users")
+	assert.Contains(s.T(), "GET /users HTTP/1.1", traefikResp.Body, "traefik backend should see URI /users")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewriteRoot() {
@@ -298,8 +278,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewriteRoot() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET / HTTP/1.1", "nginx backend should see URI /")
-	assert.Contains(s.T(), traefikResp.Body, "GET / HTTP/1.1", "traefik backend should see URI /")
+	assert.Contains(s.T(), "GET / HTTP/1.1", nginxResp.Body, "nginx backend should see URI /")
+	assert.Contains(s.T(), "GET / HTTP/1.1", traefikResp.Body, "traefik backend should see URI /")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewriteDeepPath() {
@@ -308,50 +288,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewriteDeepPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/v1/users/123")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET /v1/users/123 HTTP/1.1", "nginx backend should see URI /v1/users/123")
-	assert.Contains(s.T(), traefikResp.Body, "GET /v1/users/123 HTTP/1.1", "traefik backend should see URI /v1/users/123")
-}
-
-// requestAppRoot makes the same HTTP request against both clusters using the app-root hosts.
-func (s *RewriteTargetSuite) requestAppRoot(method, path string, headers map[string]string) (traefikResp, nginxResp *Response) {
-	s.T().Helper()
-
-	traefikResp = s.traefik.MakeRequest(s.T(), appRootTraefikHost, method, path, headers, 3, 1*time.Second)
-	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
-
-	nginxResp = s.nginx.MakeRequest(s.T(), appRootNginxHost, method, path, headers, 3, 1*time.Second)
-	require.NotNil(s.T(), nginxResp, "nginx response should not be nil")
-
-	return traefikResp, nginxResp
-}
-
-func (s *RewriteTargetSuite) TestAppRootRedirect() {
-	traefikResp, nginxResp := s.requestAppRoot(http.MethodGet, "/", nil)
-
-	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
-
-	traefikLocation := traefikResp.ResponseHeaders.Get("Location")
-	assert.True(s.T(), strings.HasSuffix(traefikLocation, "/dashboard"),
-		"traefik Location header should end with /dashboard, got: %s", traefikLocation)
-}
-
-func (s *RewriteTargetSuite) TestAppRootRedirectLocation() {
-	traefikResp, nginxResp := s.requestAppRoot(http.MethodGet, "/", nil)
-
-	traefikLocation := traefikResp.ResponseHeaders.Get("Location")
-	nginxLocation := nginxResp.ResponseHeaders.Get("Location")
-
-	assert.True(s.T(), strings.HasSuffix(traefikLocation, "/dashboard"),
-		"traefik Location header should end with /dashboard, got: %s", traefikLocation)
-	assert.True(s.T(), strings.HasSuffix(nginxLocation, "/dashboard"),
-		"nginx Location header should end with /dashboard, got: %s", nginxLocation)
-}
-
-func (s *RewriteTargetSuite) TestAppRootNonRootPassthrough() {
-	traefikResp, nginxResp := s.requestAppRoot(http.MethodGet, "/other", nil)
-
-	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
-	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for non-root path /other")
+	assert.Contains(s.T(), "GET /v1/users/123 HTTP/1.1", nginxResp.Body, "nginx backend should see URI /v1/users/123")
+	assert.Contains(s.T(), "GET /v1/users/123 HTTP/1.1", traefikResp.Body, "traefik backend should see URI /v1/users/123")
 }
 
 // requestNoRegex makes the same HTTP request against both clusters using the no-regex ingress hosts.
@@ -377,8 +315,8 @@ func (s *RewriteTargetSuite) TestNoRegexRewriteBehavior() {
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /")
 
 	// Both should rewrite to /rewritten since rewrite-target applies regardless of use-regex.
-	assert.Contains(s.T(), nginxResp.Body, "GET /rewritten HTTP/1.1", "nginx backend should see rewritten URI")
-	assert.Contains(s.T(), traefikResp.Body, "GET /rewritten HTTP/1.1", "traefik backend should see rewritten URI")
+	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", nginxResp.Body, "nginx backend should see rewritten URI")
+	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", traefikResp.Body, "traefik backend should see rewritten URI")
 }
 
 // requestExactPath makes the same HTTP request against both clusters using the exact-path rewrite hosts.
@@ -400,8 +338,8 @@ func (s *RewriteTargetSuite) TestExactPathRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /original")
 
-	assert.Contains(s.T(), nginxResp.Body, "GET /rewritten HTTP/1.1", "nginx backend should see URI /rewritten")
-	assert.Contains(s.T(), traefikResp.Body, "GET /rewritten HTTP/1.1", "traefik backend should see URI /rewritten")
+	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", nginxResp.Body, "nginx backend should see URI /rewritten")
+	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", traefikResp.Body, "traefik backend should see URI /rewritten")
 }
 
 func (s *RewriteTargetSuite) TestFullPathRewriteNoRegexPath() {
@@ -414,8 +352,8 @@ func (s *RewriteTargetSuite) TestFullPathRewriteNoRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 
 	traefikResp = s.traefik.MakeRequest(s.T(), fullPathNoRegexTraefikHost, http.MethodGet, "/original/other", nil, 3, 1*time.Second)
 	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
@@ -426,8 +364,8 @@ func (s *RewriteTargetSuite) TestFullPathRewriteNoRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 
 	traefikResp = s.traefik.MakeRequest(s.T(), fullPathNoRegexTraefikHost, http.MethodGet, "/original/a/b/c", nil, 3, 1*time.Second)
 	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
@@ -438,8 +376,8 @@ func (s *RewriteTargetSuite) TestFullPathRewriteNoRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 }
 
 func (s *RewriteTargetSuite) TestFullPathRewriteWithRegexPath() {
@@ -452,8 +390,8 @@ func (s *RewriteTargetSuite) TestFullPathRewriteWithRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 
 	traefikResp = s.traefik.MakeRequest(s.T(), fullPathWithPathRegexTraefikHost, http.MethodGet, "/original/other", nil, 3, 1*time.Second)
 	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")

--- a/e2e/rewritetarget_suite_test.go
+++ b/e2e/rewritetarget_suite_test.go
@@ -248,8 +248,8 @@ func (s *RewriteTargetSuite) TestSimpleRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /app")
 
-	assert.Contains(s.T(), "GET / HTTP/1.1", nginxResp.Body, "nginx backend should see URI /")
-	assert.Contains(s.T(), "GET / HTTP/1.1", traefikResp.Body, "traefik backend should see URI /")
+	assert.Contains(s.T(), nginxResp.Body, "GET / HTTP/1.1", "nginx backend should see URI /")
+	assert.Contains(s.T(), traefikResp.Body, "GET / HTTP/1.1", "traefik backend should see URI /")
 }
 
 func (s *RewriteTargetSuite) TestSimpleRewriteSubpath() {
@@ -258,8 +258,8 @@ func (s *RewriteTargetSuite) TestSimpleRewriteSubpath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /app/hello")
 
-	assert.Contains(s.T(), "GET /hello HTTP/1.1", nginxResp.Body, "nginx backend should see URI /hello")
-	assert.Contains(s.T(), "GET /hello HTTP/1.1", traefikResp.Body, "traefik backend should see URI /hello")
+	assert.Contains(s.T(), nginxResp.Body, "GET /hello HTTP/1.1", "nginx backend should see URI /hello")
+	assert.Contains(s.T(), traefikResp.Body, "GET /hello HTTP/1.1", "traefik backend should see URI /hello")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewrite() {
@@ -268,8 +268,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/users")
 
-	assert.Contains(s.T(), "GET /users HTTP/1.1", nginxResp.Body, "nginx backend should see URI /users")
-	assert.Contains(s.T(), "GET /users HTTP/1.1", traefikResp.Body, "traefik backend should see URI /users")
+	assert.Contains(s.T(), nginxResp.Body, "GET /users HTTP/1.1", "nginx backend should see URI /users")
+	assert.Contains(s.T(), traefikResp.Body, "GET /users HTTP/1.1", "traefik backend should see URI /users")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewriteRoot() {
@@ -278,8 +278,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewriteRoot() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/")
 
-	assert.Contains(s.T(), "GET / HTTP/1.1", nginxResp.Body, "nginx backend should see URI /")
-	assert.Contains(s.T(), "GET / HTTP/1.1", traefikResp.Body, "traefik backend should see URI /")
+	assert.Contains(s.T(), nginxResp.Body, "GET / HTTP/1.1", "nginx backend should see URI /")
+	assert.Contains(s.T(), traefikResp.Body, "GET / HTTP/1.1", "traefik backend should see URI /")
 }
 
 func (s *RewriteTargetSuite) TestCaptureGroupRewriteDeepPath() {
@@ -288,8 +288,8 @@ func (s *RewriteTargetSuite) TestCaptureGroupRewriteDeepPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /api/v1/users/123")
 
-	assert.Contains(s.T(), "GET /v1/users/123 HTTP/1.1", nginxResp.Body, "nginx backend should see URI /v1/users/123")
-	assert.Contains(s.T(), "GET /v1/users/123 HTTP/1.1", traefikResp.Body, "traefik backend should see URI /v1/users/123")
+	assert.Contains(s.T(), nginxResp.Body, "GET /v1/users/123 HTTP/1.1", "nginx backend should see URI /v1/users/123")
+	assert.Contains(s.T(), traefikResp.Body, "GET /v1/users/123 HTTP/1.1", "traefik backend should see URI /v1/users/123")
 }
 
 // requestNoRegex makes the same HTTP request against both clusters using the no-regex ingress hosts.
@@ -315,8 +315,8 @@ func (s *RewriteTargetSuite) TestNoRegexRewriteBehavior() {
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /")
 
 	// Both should rewrite to /rewritten since rewrite-target applies regardless of use-regex.
-	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", nginxResp.Body, "nginx backend should see rewritten URI")
-	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", traefikResp.Body, "traefik backend should see rewritten URI")
+	assert.Contains(s.T(), nginxResp.Body, "GET /rewritten HTTP/1.1", "nginx backend should see rewritten URI")
+	assert.Contains(s.T(), traefikResp.Body, "GET /rewritten HTTP/1.1", "traefik backend should see rewritten URI")
 }
 
 // requestExactPath makes the same HTTP request against both clusters using the exact-path rewrite hosts.
@@ -338,8 +338,8 @@ func (s *RewriteTargetSuite) TestExactPathRewrite() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode, "expected 200 for /original")
 
-	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", nginxResp.Body, "nginx backend should see URI /rewritten")
-	assert.Contains(s.T(), "GET /rewritten HTTP/1.1", traefikResp.Body, "traefik backend should see URI /rewritten")
+	assert.Contains(s.T(), nginxResp.Body, "GET /rewritten HTTP/1.1", "nginx backend should see URI /rewritten")
+	assert.Contains(s.T(), traefikResp.Body, "GET /rewritten HTTP/1.1", "traefik backend should see URI /rewritten")
 }
 
 func (s *RewriteTargetSuite) TestFullPathRewriteNoRegexPath() {
@@ -402,8 +402,8 @@ func (s *RewriteTargetSuite) TestFullPathRewriteWithRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/other", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/other", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/other", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/other", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 
 	traefikResp = s.traefik.MakeRequest(s.T(), fullPathWithPathRegexTraefikHost, http.MethodGet, "/original/a/b/c", nil, 3, 1*time.Second)
 	require.NotNil(s.T(), traefikResp, "traefik response should not be nil")
@@ -414,6 +414,6 @@ func (s *RewriteTargetSuite) TestFullPathRewriteWithRegexPath() {
 	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
 	assert.Equal(s.T(), http.StatusFound, traefikResp.StatusCode, "expected 302")
 
-	assert.Equal(s.T(), nginxResp.ResponseHeaders.Get("Location"), "https://bar.example.org/a/b/c", "nginx backend should redirect to rewrite target full URL")
-	assert.Equal(s.T(), traefikResp.ResponseHeaders.Get("Location"), "https://bar.example.org/a/b/c", "traefik backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/a/b/c", nginxResp.ResponseHeaders.Get("Location"), "nginx backend should redirect to rewrite target full URL")
+	assert.Equal(s.T(), "https://bar.example.org/a/b/c", traefikResp.ResponseHeaders.Get("Location"), "traefik backend should redirect to rewrite target full URL")
 }


### PR DESCRIPTION
This PR refactors the rewrite target e2e tests and extracts the app root tests in a new file.
Moreover, it introduces new test cases for app-root annotation.