### PR TITLE
add one-shot JSON/Markdown report output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -269,6 +269,7 @@ func writeReport(report analyzer.Report, format string, summary bool, outputFile
 
 	if err := render.Render(report, format, summary, f); err != nil {
 		_ = f.Close()
+		_ = os.Remove(outputFile)
 		return err
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,20 +111,8 @@ func main() {
 }
 
 func run(ctx context.Context, cmd *cli.Command) error {
-	format := cmd.String(flagFormat)
-	summary := cmd.Bool(flagSummary)
-	outputFile := cmd.String(flagOutputFile)
-
-	oneShot := format != ""
-
-	// In one-shot mode stdout is reserved for the report, so logs go to stderr.
-	logOut := io.Writer(os.Stdout)
-	if oneShot {
-		logOut = os.Stderr
-	}
-	logger.Setup("info", logOut)
-
-	if err := validateOutputFlags(format, summary, outputFile); err != nil {
+	oneShot, err := planOneShot(cmd)
+	if err != nil {
 		return err
 	}
 
@@ -160,8 +148,8 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// One-shot mode: write the report once and exit without serving.
-	if oneShot {
-		return writeReport(analyzr.Report(), format, summary, outputFile)
+	if oneShot != nil {
+		return writeReport(analyzr.Report(), oneShot.format, oneShot.summary, oneShot.outputFile)
 	}
 
 	// Creates the platform client.
@@ -212,6 +200,40 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return nil
+}
+
+// oneShotOutput captures the validated configuration for a one-shot report
+// invocation. A nil *oneShotOutput means the tool runs in serve mode.
+type oneShotOutput struct {
+	format     string
+	summary    bool
+	outputFile string
+}
+
+// planOneShot reads the output-related flags, validates them, configures the
+// logger (stderr in one-shot mode, stdout otherwise), and returns the one-shot
+// output config — or nil for serve mode.
+func planOneShot(cmd *cli.Command) (*oneShotOutput, error) {
+	format := cmd.String(flagFormat)
+	summary := cmd.Bool(flagSummary)
+	outputFile := cmd.String(flagOutputFile)
+
+	if err := validateOutputFlags(format, summary, outputFile); err != nil {
+		return nil, err
+	}
+
+	// In one-shot mode stdout is reserved for the report, so logs go to stderr.
+	logOut := io.Writer(os.Stdout)
+	if format != "" {
+		logOut = os.Stderr
+	}
+	logger.Setup("info", logOut)
+
+	if format == "" {
+		return nil, nil
+	}
+
+	return &oneShotOutput{format: format, summary: summary, outputFile: outputFile}, nil
 }
 
 // validateOutputFlags rejects flag combinations that don't make sense for the

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/traefik/ingress-nginx-migration/pkg/client"
 	"github.com/traefik/ingress-nginx-migration/pkg/handlers"
 	"github.com/traefik/ingress-nginx-migration/pkg/logger"
+	"github.com/traefik/ingress-nginx-migration/pkg/render"
 	"github.com/urfave/cli/v3"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -31,6 +33,9 @@ const (
 	flagControllerClass    = "controller-class"
 	flagWatchWithoutClass  = "watch-ingress-without-class"
 	flagIngressClassByName = "ingress-class-by-name"
+	flagFormat             = "format"
+	flagOutputFile         = "output-file"
+	flagSummary            = "summary"
 )
 
 func main() {
@@ -81,6 +86,21 @@ func main() {
 				Usage:   "Defines if Ingress Controller should watch for Ingress Class by Name together with Controller Class.",
 				Sources: cli.EnvVars(strcase.ToSNAKE(flagIngressClassByName)),
 			},
+			&cli.StringFlag{
+				Name:    flagFormat,
+				Usage:   "Output the report once in this format ('json' or 'markdown') and exit, instead of serving the HTML report. When empty, the HTML report is served.",
+				Sources: cli.EnvVars(strcase.ToSNAKE(flagFormat)),
+			},
+			&cli.StringFlag{
+				Name:    flagOutputFile,
+				Usage:   "Write the one-shot report to this file instead of stdout. Requires --format. Overwrites an existing file.",
+				Sources: cli.EnvVars(strcase.ToSNAKE(flagOutputFile)),
+			},
+			&cli.BoolFlag{
+				Name:    flagSummary,
+				Usage:   "Omit the per-Ingress detail from the report. Only valid with --format markdown.",
+				Sources: cli.EnvVars(strcase.ToSNAKE(flagSummary)),
+			},
 		},
 		Action: run,
 	}
@@ -91,7 +111,22 @@ func main() {
 }
 
 func run(ctx context.Context, cmd *cli.Command) error {
-	logger.Setup("info")
+	format := cmd.String(flagFormat)
+	summary := cmd.Bool(flagSummary)
+	outputFile := cmd.String(flagOutputFile)
+
+	oneShot := format != ""
+
+	// In one-shot mode stdout is reserved for the report, so logs go to stderr.
+	logOut := io.Writer(os.Stdout)
+	if oneShot {
+		logOut = os.Stderr
+	}
+	logger.Setup("info", logOut)
+
+	if err := validateOutputFlags(format, summary, outputFile); err != nil {
+		return err
+	}
 
 	// Creates the Kubernetes client.
 	config, err := rest.InClusterConfig()
@@ -122,6 +157,11 @@ func run(ctx context.Context, cmd *cli.Command) error {
 
 	if err = analyzr.GenerateReport(); err != nil {
 		return fmt.Errorf("generating report: %w", err)
+	}
+
+	// One-shot mode: write the report once and exit without serving.
+	if oneShot {
+		return writeReport(analyzr.Report(), format, summary, outputFile)
 	}
 
 	// Creates the platform client.
@@ -169,6 +209,49 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		_ = server.Close()
 	case err := <-errCh:
 		return fmt.Errorf("analyzer server error: %w", err)
+	}
+
+	return nil
+}
+
+// validateOutputFlags rejects flag combinations that don't make sense for the
+// one-shot output mode.
+func validateOutputFlags(format string, summary bool, outputFile string) error {
+	switch format {
+	case "", render.FormatJSON, render.FormatMarkdown:
+	default:
+		return fmt.Errorf("invalid --%s %q (must be %q or %q)", flagFormat, format, render.FormatJSON, render.FormatMarkdown)
+	}
+
+	if format == "" && outputFile != "" {
+		return fmt.Errorf("--%s requires --%s", flagOutputFile, flagFormat)
+	}
+
+	if summary && format != render.FormatMarkdown {
+		return fmt.Errorf("--%s is only valid with --%s %s", flagSummary, flagFormat, render.FormatMarkdown)
+	}
+
+	return nil
+}
+
+// writeReport renders the report to outputFile, or to stdout when outputFile is empty.
+func writeReport(report analyzer.Report, format string, summary bool, outputFile string) error {
+	if outputFile == "" {
+		return render.Render(report, format, summary, os.Stdout)
+	}
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+
+	if err := render.Render(report, format, summary, f); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing output file: %w", err)
 	}
 
 	return nil

--- a/pkg/analyzer/report.go
+++ b/pkg/analyzer/report.go
@@ -229,8 +229,10 @@ type Report struct {
 	Version        string    `json:"version"`
 
 	// Hash is a SHA-256 hash of the report content (excluding GenerationDate).
-	// Used for localStorage persistence to detect report changes.
-	Hash string `json:"-"`
+	// Used for localStorage persistence to detect report changes, and exposed in
+	// JSON output so automation can detect meaningful changes while ignoring the
+	// noisy GenerationDate timestamp.
+	Hash string `json:"hash"`
 
 	IngressCount        int            `json:"ingressCount"`
 	IngressCountByClass map[string]int `json:"ingressCountByClass"`
@@ -345,6 +347,16 @@ func (a *Analyzer) computeReport(ingressClasses []*netv1.IngressClass, ingresses
 		report.SupportedIngressAnnotations = append(report.SupportedIngressAnnotations, AnnotationInfo{Name: ann, Version: ver})
 	}
 	slices.SortFunc(report.SupportedIngressAnnotations, func(a, b AnnotationInfo) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Sort unsupported ingresses by namespace then name so that the report (and
+	// its JSON/Markdown rendering) is deterministic across runs. Listers return
+	// items in indexer order, which is not stable.
+	slices.SortFunc(report.UnsupportedIngresses, func(a, b IngressReport) int {
+		if c := cmp.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
 		return cmp.Compare(a.Name, b.Name)
 	})
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -10,11 +9,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Setup is configuring the logger.
-func Setup(level string) {
-	var w io.Writer = os.Stdout
+// Setup is configuring the logger to write to out.
+// One-shot output modes pass os.Stderr so that stdout stays reserved for the
+// machine- or human-readable report.
+func Setup(level string, out io.Writer) {
 	writer := zerolog.ConsoleWriter{
-		Out:        w,
+		Out:        out,
 		TimeFormat: time.RFC3339,
 	}
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -29,9 +29,12 @@ var markdownTemplate string
 // Render writes report to w in the given format.
 //
 // summary only applies to FormatMarkdown, where it omits the per-Ingress detail
-// table. The caller is responsible for rejecting summary with other formats; see
-// cmd flag validation.
+// table. Passing summary=true with any other format is an error.
 func Render(report analyzer.Report, format string, summary bool, w io.Writer) error {
+	if summary && format != FormatMarkdown {
+		return fmt.Errorf("--summary is only valid with format %q, got %q", FormatMarkdown, format)
+	}
+
 	switch format {
 	case FormatJSON:
 		return renderJSON(report, w)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,0 +1,189 @@
+// Package render serializes an analyzer.Report into machine- or human-readable
+// formats for the one-shot output mode. It has no knowledge of HTTP; the HTML
+// web view lives in pkg/handlers.
+package render
+
+import (
+	"cmp"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/traefik/ingress-nginx-migration/pkg/analyzer"
+)
+
+// Supported output formats for the one-shot mode.
+const (
+	FormatJSON     = "json"
+	FormatMarkdown = "markdown"
+)
+
+//go:embed report.md.tmpl
+var markdownTemplate string
+
+// Render writes report to w in the given format.
+//
+// summary only applies to FormatMarkdown, where it omits the per-Ingress detail
+// table. The caller is responsible for rejecting summary with other formats; see
+// cmd flag validation.
+func Render(report analyzer.Report, format string, summary bool, w io.Writer) error {
+	switch format {
+	case FormatJSON:
+		return renderJSON(report, w)
+	case FormatMarkdown:
+		return renderMarkdown(report, summary, w)
+	default:
+		return fmt.Errorf("unknown format %q (must be %q or %q)", format, FormatJSON, FormatMarkdown)
+	}
+}
+
+// renderJSON writes the full analyzer.Report as indented JSON with a trailing
+// newline. The internal struct is the public contract by design.
+func renderJSON(report analyzer.Report, w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("encoding report as JSON: %w", err)
+	}
+
+	return nil
+}
+
+// blockingRow is one annotation that prevents automatic migration, with how many
+// Ingresses carry it and whether it is a known-unsupported or an unknown annotation.
+type blockingRow struct {
+	Annotation string
+	Count      int
+	Kind       string // "unsupported" or "unknown"
+}
+
+// detailRow is one Ingress that needs manual attention.
+type detailRow struct {
+	Namespace string
+	Name      string
+	Class     string
+	Fixes     string // comma-joined unsupported + unknown annotations
+}
+
+// markdownView is the pre-computed, deterministically-ordered view model handed
+// to the Markdown template, so the template itself stays free of sorting and
+// formatting logic.
+type markdownView struct {
+	GeneratedAt string
+	Version     string
+	Hash        string
+
+	IngressCount     int
+	CompatibleCount  int
+	CompatiblePct    string
+	VanillaCount     int
+	VanillaPct       string
+	SupportedCount   int
+	SupportedPct     string
+	UnsupportedCount int
+	UnsupportedPct   string
+
+	V36 int
+	V37 int
+	Hub int
+
+	Blocking []blockingRow
+
+	ShowDetail bool
+	Detail     []detailRow
+}
+
+func renderMarkdown(report analyzer.Report, summary bool, w io.Writer) error {
+	tmpl, err := template.New("report.md").Parse(markdownTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing markdown template: %w", err)
+	}
+
+	if err := tmpl.Execute(w, buildMarkdownView(report, summary)); err != nil {
+		return fmt.Errorf("executing markdown template: %w", err)
+	}
+
+	return nil
+}
+
+func buildMarkdownView(report analyzer.Report, summary bool) markdownView {
+	view := markdownView{
+		GeneratedAt:      report.GenerationDate.UTC().Format(time.RFC3339),
+		Version:          report.Version,
+		Hash:             report.Hash,
+		IngressCount:     report.IngressCount,
+		CompatibleCount:  report.CompatibleIngressCount,
+		CompatiblePct:    formatPct(report.CompatibleIngressPercentage),
+		VanillaCount:     report.VanillaIngressCount,
+		VanillaPct:       formatPct(report.VanillaIngressPercentage),
+		SupportedCount:   report.SupportedIngressCount,
+		SupportedPct:     formatPct(report.SupportedIngressPercentage),
+		UnsupportedCount: report.UnsupportedIngressCount,
+		UnsupportedPct:   formatPct(report.UnsupportedIngressPercentage),
+		V36:              report.CompatibleV36IngressCount,
+		V37:              report.CompatibleV37IngressCount,
+		Hub:              report.CompatibleHubIngressCount,
+		Blocking:         buildBlockingRows(report),
+		ShowDetail:       !summary,
+	}
+
+	if view.ShowDetail {
+		view.Detail = buildDetailRows(report.UnsupportedIngresses)
+	}
+
+	return view
+}
+
+// buildBlockingRows merges the known-unsupported and unknown annotation
+// frequencies into a single list, sorted by descending count then name so the
+// most impactful blockers surface first and the order is deterministic.
+func buildBlockingRows(report analyzer.Report) []blockingRow {
+	rows := make([]blockingRow, 0, len(report.UnsupportedIngressAnnotations)+len(report.UnknownIngressAnnotations))
+
+	for ann, count := range report.UnsupportedIngressAnnotations {
+		rows = append(rows, blockingRow{Annotation: ann, Count: count, Kind: "unsupported"})
+	}
+	for ann, count := range report.UnknownIngressAnnotations {
+		rows = append(rows, blockingRow{Annotation: ann, Count: count, Kind: "unknown"})
+	}
+
+	slices.SortFunc(rows, func(a, b blockingRow) int {
+		if c := cmp.Compare(b.Count, a.Count); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Annotation, b.Annotation)
+	})
+
+	return rows
+}
+
+// buildDetailRows turns the (already namespace/name-sorted) unsupported Ingresses
+// into table rows listing the specific annotations a human must migrate.
+func buildDetailRows(ingresses []analyzer.IngressReport) []detailRow {
+	rows := make([]detailRow, 0, len(ingresses))
+
+	for _, ing := range ingresses {
+		fixes := make([]string, 0, len(ing.UnsupportedAnnotations)+len(ing.UnknownAnnotations))
+		fixes = append(fixes, ing.UnsupportedAnnotations...)
+		fixes = append(fixes, ing.UnknownAnnotations...)
+
+		rows = append(rows, detailRow{
+			Namespace: ing.Namespace,
+			Name:      ing.Name,
+			Class:     ing.IngressClassName,
+			Fixes:     strings.Join(fixes, ", "),
+		})
+	}
+
+	return rows
+}
+
+func formatPct(pct float64) string {
+	return fmt.Sprintf("%.1f%%", pct)
+}

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -126,7 +126,7 @@ func TestRender(t *testing.T) {
 
 			goldenPath := filepath.Join("testdata", tt.golden)
 			if *update {
-				require.NoError(t, os.WriteFile(goldenPath, buf.Bytes(), 0o644))
+				require.NoError(t, os.WriteFile(goldenPath, buf.Bytes(), 0o600))
 			}
 
 			want, err := os.ReadFile(goldenPath)

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -1,0 +1,146 @@
+package render
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/ingress-nginx-migration/pkg/analyzer"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+// mixedReport has vanilla, supported and unsupported (known-unsupported + unknown)
+// Ingresses, so every section of every renderer has content.
+func mixedReport() analyzer.Report {
+	return analyzer.Report{
+		GenerationDate:               time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC),
+		Version:                      "v0.3.0",
+		Hash:                         "abc123def456",
+		IngressCount:                 4,
+		IngressCountByClass:          map[string]int{"nginx": 4},
+		CompatibleIngressCount:       2,
+		CompatibleIngressPercentage:  50.0,
+		VanillaIngressCount:          1,
+		VanillaIngressPercentage:     25.0,
+		SupportedIngressCount:        1,
+		SupportedIngressPercentage:   25.0,
+		UnsupportedIngressCount:      2,
+		UnsupportedIngressPercentage: 50.0,
+		UnsupportedIngressAnnotations: map[string]int{
+			"nginx.ingress.kubernetes.io/limit-connections": 2,
+		},
+		UnknownIngressAnnotations: map[string]int{
+			"nginx.ingress.kubernetes.io/totally-made-up": 1,
+		},
+		UnsupportedIngresses: []analyzer.IngressReport{
+			{
+				Name:                   "api",
+				Namespace:              "prod",
+				IngressClassName:       "nginx",
+				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-connections"},
+			},
+			{
+				Name:                   "web",
+				Namespace:              "prod",
+				IngressClassName:       "nginx",
+				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-connections"},
+				UnknownAnnotations:     []string{"nginx.ingress.kubernetes.io/totally-made-up"},
+			},
+		},
+		SupportedIngressAnnotations: []analyzer.AnnotationInfo{
+			{Name: "nginx.ingress.kubernetes.io/rewrite-target", Version: "v3.7"},
+			{Name: "nginx.ingress.kubernetes.io/ssl-redirect", Version: "v3.6"},
+		},
+		CompatibleV36IngressCount: 1,
+		CompatibleV37IngressCount: 1,
+		CompatibleHubIngressCount: 0,
+	}
+}
+
+// compatibleReport has no unsupported Ingresses, exercising the "None" branches.
+func compatibleReport() analyzer.Report {
+	return analyzer.Report{
+		GenerationDate:                time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC),
+		Version:                       "v0.3.0",
+		Hash:                          "allgood",
+		IngressCount:                  3,
+		IngressCountByClass:           map[string]int{"nginx": 3},
+		CompatibleIngressCount:        3,
+		CompatibleIngressPercentage:   100.0,
+		VanillaIngressCount:           1,
+		VanillaIngressPercentage:      33.33333333333333,
+		SupportedIngressCount:         2,
+		SupportedIngressPercentage:    66.66666666666666,
+		UnsupportedIngressAnnotations: map[string]int{},
+		UnknownIngressAnnotations:     map[string]int{},
+		SupportedIngressAnnotations: []analyzer.AnnotationInfo{
+			{Name: "nginx.ingress.kubernetes.io/ssl-redirect", Version: "v3.6"},
+		},
+		CompatibleV36IngressCount: 2,
+		CompatibleV37IngressCount: 1,
+	}
+}
+
+// emptyReport is an analysis of a cluster with no in-scope Ingresses.
+func emptyReport() analyzer.Report {
+	return analyzer.Report{
+		GenerationDate:                time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC),
+		Version:                       "v0.3.0",
+		Hash:                          "empty",
+		IngressCountByClass:           map[string]int{},
+		UnsupportedIngressAnnotations: map[string]int{},
+		UnknownIngressAnnotations:     map[string]int{},
+	}
+}
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		report  analyzer.Report
+		format  string
+		summary bool
+		golden  string
+	}{
+		{name: "mixed json", report: mixedReport(), format: FormatJSON, golden: "mixed.json"},
+		{name: "mixed markdown full", report: mixedReport(), format: FormatMarkdown, golden: "mixed.full.md"},
+		{name: "mixed markdown summary", report: mixedReport(), format: FormatMarkdown, summary: true, golden: "mixed.summary.md"},
+		{name: "compatible markdown full", report: compatibleReport(), format: FormatMarkdown, golden: "compatible.full.md"},
+		{name: "empty json", report: emptyReport(), format: FormatJSON, golden: "empty.json"},
+		{name: "empty markdown full", report: emptyReport(), format: FormatMarkdown, golden: "empty.full.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			require.NoError(t, Render(tt.report, tt.format, tt.summary, &buf))
+
+			goldenPath := filepath.Join("testdata", tt.golden)
+			if *update {
+				require.NoError(t, os.WriteFile(goldenPath, buf.Bytes(), 0o644))
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			require.NoError(t, err)
+			assert.Equal(t, string(want), buf.String())
+		})
+	}
+}
+
+func TestRenderUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := Render(mixedReport(), "yaml", false, &buf)
+	require.Error(t, err)
+	assert.Empty(t, buf.String())
+}

--- a/pkg/render/report.md.tmpl
+++ b/pkg/render/report.md.tmpl
@@ -1,0 +1,44 @@
+# Traefik Migration Report
+
+Generated: {{ .GeneratedAt }} · tool {{ .Version }}
+Hash: `{{ .Hash }}`
+
+## Summary
+
+| Metric | Count | % |
+|---|---|---|
+| Total | {{ .IngressCount }} | 100% |
+| Compatible | {{ .CompatibleCount }} | {{ .CompatiblePct }} |
+| • Vanilla | {{ .VanillaCount }} | {{ .VanillaPct }} |
+| • Supported | {{ .SupportedCount }} | {{ .SupportedPct }} |
+| Unsupported | {{ .UnsupportedCount }} | {{ .UnsupportedPct }} |
+
+## Minimum Traefik version
+
+| v3.6 | v3.7 | Hub |
+|---|---|---|
+| {{ .V36 }} | {{ .V37 }} | {{ .Hub }} |
+
+## Blocking annotations
+{{ if .Blocking }}
+| Annotation | Count | Kind |
+|---|---|---|
+{{- range .Blocking }}
+| `{{ .Annotation }}` | {{ .Count }} | {{ .Kind }} |
+{{- end }}
+{{- else }}
+None 🎉
+{{- end }}
+{{- if .ShowDetail }}
+
+## Ingresses needing manual work
+{{ if .Detail }}
+| Namespace | Name | Class | Annotations to fix |
+|---|---|---|---|
+{{- range .Detail }}
+| {{ .Namespace }} | {{ .Name }} | {{ .Class }} | {{ .Fixes }} |
+{{- end }}
+{{- else }}
+None 🎉
+{{- end }}
+{{- end }}

--- a/pkg/render/testdata/compatible.full.md
+++ b/pkg/render/testdata/compatible.full.md
@@ -1,0 +1,28 @@
+# Traefik Migration Report
+
+Generated: 2026-05-27T10:00:00Z · tool v0.3.0
+Hash: `allgood`
+
+## Summary
+
+| Metric | Count | % |
+|---|---|---|
+| Total | 3 | 100% |
+| Compatible | 3 | 100.0% |
+| • Vanilla | 1 | 33.3% |
+| • Supported | 2 | 66.7% |
+| Unsupported | 0 | 0.0% |
+
+## Minimum Traefik version
+
+| v3.6 | v3.7 | Hub |
+|---|---|---|
+| 2 | 1 | 0 |
+
+## Blocking annotations
+
+None 🎉
+
+## Ingresses needing manual work
+
+None 🎉

--- a/pkg/render/testdata/empty.full.md
+++ b/pkg/render/testdata/empty.full.md
@@ -1,0 +1,28 @@
+# Traefik Migration Report
+
+Generated: 2026-05-27T10:00:00Z · tool v0.3.0
+Hash: `empty`
+
+## Summary
+
+| Metric | Count | % |
+|---|---|---|
+| Total | 0 | 100% |
+| Compatible | 0 | 0.0% |
+| • Vanilla | 0 | 0.0% |
+| • Supported | 0 | 0.0% |
+| Unsupported | 0 | 0.0% |
+
+## Minimum Traefik version
+
+| v3.6 | v3.7 | Hub |
+|---|---|---|
+| 0 | 0 | 0 |
+
+## Blocking annotations
+
+None 🎉
+
+## Ingresses needing manual work
+
+None 🎉

--- a/pkg/render/testdata/empty.json
+++ b/pkg/render/testdata/empty.json
@@ -1,0 +1,22 @@
+{
+  "generationDate": "2026-05-27T10:00:00Z",
+  "version": "v0.3.0",
+  "hash": "empty",
+  "ingressCount": 0,
+  "ingressCountByClass": {},
+  "compatibleIngressCount": 0,
+  "compatibleIngressPercentage": 0,
+  "vanillaIngressCount": 0,
+  "vanillaIngressPercentage": 0,
+  "supportedIngressCount": 0,
+  "supportedIngressPercentage": 0,
+  "unsupportedIngressCount": 0,
+  "unsupportedIngressPercentage": 0,
+  "unsupportedIngressAnnotations": {},
+  "unknownIngressAnnotations": {},
+  "unsupportedIngresses": null,
+  "supportedIngressAnnotations": null,
+  "compatibleV36IngressCount": 0,
+  "compatibleV37IngressCount": 0,
+  "compatibleHubIngressCount": 0
+}

--- a/pkg/render/testdata/mixed.full.md
+++ b/pkg/render/testdata/mixed.full.md
@@ -1,0 +1,34 @@
+# Traefik Migration Report
+
+Generated: 2026-05-27T10:00:00Z · tool v0.3.0
+Hash: `abc123def456`
+
+## Summary
+
+| Metric | Count | % |
+|---|---|---|
+| Total | 4 | 100% |
+| Compatible | 2 | 50.0% |
+| • Vanilla | 1 | 25.0% |
+| • Supported | 1 | 25.0% |
+| Unsupported | 2 | 50.0% |
+
+## Minimum Traefik version
+
+| v3.6 | v3.7 | Hub |
+|---|---|---|
+| 1 | 1 | 0 |
+
+## Blocking annotations
+
+| Annotation | Count | Kind |
+|---|---|---|
+| `nginx.ingress.kubernetes.io/limit-connections` | 2 | unsupported |
+| `nginx.ingress.kubernetes.io/totally-made-up` | 1 | unknown |
+
+## Ingresses needing manual work
+
+| Namespace | Name | Class | Annotations to fix |
+|---|---|---|---|
+| prod | api | nginx | nginx.ingress.kubernetes.io/limit-connections |
+| prod | web | nginx | nginx.ingress.kubernetes.io/limit-connections, nginx.ingress.kubernetes.io/totally-made-up |

--- a/pkg/render/testdata/mixed.json
+++ b/pkg/render/testdata/mixed.json
@@ -1,0 +1,57 @@
+{
+  "generationDate": "2026-05-27T10:00:00Z",
+  "version": "v0.3.0",
+  "hash": "abc123def456",
+  "ingressCount": 4,
+  "ingressCountByClass": {
+    "nginx": 4
+  },
+  "compatibleIngressCount": 2,
+  "compatibleIngressPercentage": 50,
+  "vanillaIngressCount": 1,
+  "vanillaIngressPercentage": 25,
+  "supportedIngressCount": 1,
+  "supportedIngressPercentage": 25,
+  "unsupportedIngressCount": 2,
+  "unsupportedIngressPercentage": 50,
+  "unsupportedIngressAnnotations": {
+    "nginx.ingress.kubernetes.io/limit-connections": 2
+  },
+  "unknownIngressAnnotations": {
+    "nginx.ingress.kubernetes.io/totally-made-up": 1
+  },
+  "unsupportedIngresses": [
+    {
+      "name": "api",
+      "namespace": "prod",
+      "ingressClassName": "nginx",
+      "unsupportedAnnotations": [
+        "nginx.ingress.kubernetes.io/limit-connections"
+      ]
+    },
+    {
+      "name": "web",
+      "namespace": "prod",
+      "ingressClassName": "nginx",
+      "unsupportedAnnotations": [
+        "nginx.ingress.kubernetes.io/limit-connections"
+      ],
+      "unknownAnnotations": [
+        "nginx.ingress.kubernetes.io/totally-made-up"
+      ]
+    }
+  ],
+  "supportedIngressAnnotations": [
+    {
+      "name": "nginx.ingress.kubernetes.io/rewrite-target",
+      "version": "v3.7"
+    },
+    {
+      "name": "nginx.ingress.kubernetes.io/ssl-redirect",
+      "version": "v3.6"
+    }
+  ],
+  "compatibleV36IngressCount": 1,
+  "compatibleV37IngressCount": 1,
+  "compatibleHubIngressCount": 0
+}

--- a/pkg/render/testdata/mixed.summary.md
+++ b/pkg/render/testdata/mixed.summary.md
@@ -1,0 +1,27 @@
+# Traefik Migration Report
+
+Generated: 2026-05-27T10:00:00Z · tool v0.3.0
+Hash: `abc123def456`
+
+## Summary
+
+| Metric | Count | % |
+|---|---|---|
+| Total | 4 | 100% |
+| Compatible | 2 | 50.0% |
+| • Vanilla | 1 | 25.0% |
+| • Supported | 1 | 25.0% |
+| Unsupported | 2 | 50.0% |
+
+## Minimum Traefik version
+
+| v3.6 | v3.7 | Hub |
+|---|---|---|
+| 1 | 1 | 0 |
+
+## Blocking annotations
+
+| Annotation | Count | Kind |
+|---|---|---|
+| `nginx.ingress.kubernetes.io/limit-connections` | 2 | unsupported |
+| `nginx.ingress.kubernetes.io/totally-made-up` | 1 | unknown |

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,9 @@ GLOBAL OPTIONS:
    --controller-class string                      Defines the Ingress Controller class to analyze. When empty, 'k8s.io/ingress-nginx' is used. [$CONTROLLER_CLASS]
    --watch-ingress-without-class                  Defines if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified. [$WATCH_INGRESS_WITHOUT_CLASS]
    --ingress-class-by-name                        Defines if Ingress Controller should watch for Ingress Class by Name together with Controller Class. [$INGRESS_CLASS_BY_NAME]
+   --format string                                Output the report once in this format ('json' or 'markdown') and exit, instead of serving the HTML report. When empty, the HTML report is served. [$FORMAT]
+   --output-file string                           Write the one-shot report to this file instead of stdout. Requires --format. Overwrites an existing file. [$OUTPUT_FILE]
+   --summary                                      Omit the per-Ingress detail from the report. Only valid with --format markdown. [$SUMMARY]
    --help, -h                                     Show help
 ```
 
@@ -104,6 +107,43 @@ GLOBAL OPTIONS:
 > ```bash
 > KUBECONFIG=~/.kube/config ingress-nginx-migration
 > ```
+
+### Output Formats
+
+The `--format` flag allows you to output the generated report to stdout or a file, in either Markdown or JSON format. 
+
+This can be useful for use in automations and keeping track of an ongoing migration.
+
+```bash
+# Machine-readable JSON to stdout:
+ingress-nginx-migration --kubeconfig ~/.kube/config --format json
+
+# Full human-readable Markdown:
+ingress-nginx-migration --kubeconfig ~/.kube/config --format markdown
+
+# Compact Markdown status (counts only, no per-Ingress detail):
+ingress-nginx-migration --kubeconfig ~/.kube/config --format markdown --summary
+```
+
+By default, these flags will write to stdout (default logs will be redirected to stderr). They can be combined with the `--output--file` flag in order to write to a file instead.
+
+
+Notes:
+
+- `--format json` emits the **full** report, including the names/namespaces of
+  Ingresses that need manual migration. It also exposes a `hash` field as a digest
+  of the report content excluding the timestamp allowing you to detect
+  changes between runs without relying on the `generationDate`.
+- `--summary` is **Markdown-only**; combining it with `--format json` will result in an error.
+- In one-shot mode logs go to **stderr**, so stdout carries only the report.
+
+- The tool only exits non-zero only on real errors (no cluster
+  access, bad flags, write failure), never because Ingresses are incompatible.
+  You can Gate a CI job on full compatibility by inspecting the JSON, e.g. with `jq`:
+
+```bash
+ingress-nginx-migration --format json | jq -e '.unsupportedIngressCount == 0'
+```
 
 ### Required Permissions
 

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ ingress-nginx-migration --kubeconfig ~/.kube/config --format markdown
 ingress-nginx-migration --kubeconfig ~/.kube/config --format markdown --summary
 ```
 
-By default, these flags will write to stdout (default logs will be redirected to stderr). They can be combined with the `--output--file` flag in order to write to a file instead.
+By default, these flags will write to stdout (default logs will be redirected to stderr). They can be combined with the `--output-file` flag in order to write to a file instead.
 
 
 Notes:


### PR DESCRIPTION
This adds new cli flags that allow markdown or JSON output either to stdout or a file:
- `--format json|markdown`
- `--output-file`
- ` --summary` - Markdown only, shorter summary report.

Also adds a `Report.Hash` in JSON output to allow detecting changes.

Logic is placed in new `pkg/render`.

`make lint test clean build` passes.

This addresses #5.

Let me know if there is anything missing or if you would like me to make changes to the approach used. 

AI assistance was used, though I have reviewed the code and tested all changes. 