### PR TITLE
Set permissions on pr workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,9 @@ on:
 env:
   golang_ci_lint_version: v2.11.2
 
+permissions:
+  contents: read
+
 jobs:
 
   ci:


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/pr.yaml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.