### PR TITLE
Add e2e tests for force-ssl-redirect bypass via X-Forwarded-Proto

### DIFF
--- a/e2e/fixtures/nginx-helmchart.yaml
+++ b/e2e/fixtures/nginx-helmchart.yaml
@@ -13,6 +13,7 @@ spec:
       allowSnippetAnnotations: true
       config:
         annotations-risk-level: Critical
+        use-forwarded-headers: "true"
       extraArgs:
         enable-ssl-passthrough: ""
       service:

--- a/e2e/sslredirect_suite_test.go
+++ b/e2e/sslredirect_suite_test.go
@@ -276,3 +276,35 @@ func (s *SSLRedirectSuite) TestSSLRedirectPreservesQueryString() {
 	assert.True(s.T(), strings.HasSuffix(gatewayLocation, "/path?key=value"),
 		"gateway Location should preserve query string, got: %s", gatewayLocation)
 }
+
+// TestSSLRedirectBypassedByXForwardedProto verifies that when X-Forwarded-Proto: https is present,
+// the ssl-redirect is skipped and the request reaches the backend (LB-terminated TLS scenario).
+// This requires nginx to be configured with use-forwarded-headers: true (set in nginx-helmchart.yaml).
+func (s *SSLRedirectSuite) TestSSLRedirectBypassedByXForwardedProto() {
+	headers := map[string]string{"X-Forwarded-Proto": "https"}
+	traefikResp, nginxResp := s.redirectRequest(http.MethodGet, "/", headers)
+
+	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode,
+		"X-Forwarded-Proto: https should bypass ssl-redirect and reach the backend")
+
+	assert.Empty(s.T(), traefikResp.ResponseHeaders.Get("Location"),
+		"traefik should not redirect when X-Forwarded-Proto is already https")
+	assert.Empty(s.T(), nginxResp.ResponseHeaders.Get("Location"),
+		"nginx should not redirect when X-Forwarded-Proto is already https (requires use-forwarded-headers: true)")
+}
+
+// TestSSLRedirectBypassXForwardedProtoPreservesPath verifies that bypassed requests preserve the request path.
+func (s *SSLRedirectSuite) TestSSLRedirectBypassXForwardedProtoPreservesPath() {
+	headers := map[string]string{"X-Forwarded-Proto": "https"}
+	traefikResp, nginxResp := s.redirectRequest(http.MethodGet, "/some/path", headers)
+
+	assert.Equal(s.T(), nginxResp.StatusCode, traefikResp.StatusCode, "status code mismatch")
+	assert.Equal(s.T(), http.StatusOK, traefikResp.StatusCode,
+		"bypassed request should reach backend")
+
+	assert.True(s.T(), strings.Contains(traefikResp.Body, "/some/path"),
+		"backend should receive the original path, traefik body: %s", traefikResp.Body)
+	assert.True(s.T(), strings.Contains(nginxResp.Body, "/some/path"),
+		"backend should receive the original path, nginx body: %s", nginxResp.Body)
+}


### PR DESCRIPTION
## Summary

Add tests to validate `force-ssl-redirect` behavior when `X-Forwarded-Proto: https` is sent by an upstream load balancer that terminates TLS.

This covers the bug fixed in traefik/traefik#13386, where requests with `X-Forwarded-Proto: https` were incorrectly routed to `noop@internal` and returned 418 instead of reaching the backend.

**New tests:**
- `TestSSLRedirectBypassedByXForwardedProto`: verifies that `X-Forwarded-Proto: https` bypasses the ssl-redirect and reaches the backend (HTTP 200)
- `TestSSLRedirectBypassXForwardedProtoPreservesPath`: verifies that the original path is preserved when the redirect is bypassed

**Fixture updates:**
- Pin Traefik helm chart to v41.0.0 and fix renamed config keys (`logs` → `log`, `kubernetesIngressNginx` → `kubernetesIngressNGINX`)
- Enable `forwardedHeaders.insecure` on the web entrypoint so Traefik trusts `X-Forwarded-Proto` from test clients (simulates a trusted upstream LB)
- Enable `use-forwarded-headers` in nginx so it also respects `X-Forwarded-Proto: https` and bypasses redirect consistently