### PR TITLE
fix: pin alpine base image, run as non-root, harden checkout credentials

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1.2
 # Alpine
-FROM alpine
+FROM alpine:3.24.1
 
 RUN apk --no-cache --no-progress add ca-certificates tzdata git \
     && rm -rf /var/cache/apk/*
 
 ARG TARGETPLATFORM
 COPY ./dist/$TARGETPLATFORM/ingress-nginx-migration /
+
+USER 65534
 
 ENTRYPOINT ["/ingress-nginx-migration"]
 EXPOSE 8080


### PR DESCRIPTION
### Motivation

Resolve ingress-nginx-migration's Aikido IaC findings and harden CI checkout credentials. The Dockerfile used `FROM alpine` (unpinned `latest`) and ran as root; it now pins the alpine base to a concrete version and runs as user `65534` (nobody) — safe since the tool is an HTTP server on `:8080` (a high port) with no file output. The `actions/checkout` steps in `pr.yaml` and `tag.yaml` set `persist-credentials: false` — the release job's `git fetch --unshallow` and goreleaser both work without the persisted token (the repo is public, and goreleaser authenticates via `GITHUB_TOKEN`).

- Docker container runs as root: https://app.aikido.dev/queue?issue_id_filter=18158985
- Automatic upgrades of base Docker images: https://app.aikido.dev/queue?issue_id_filter=18158999
- actions/checkout persists Git credentials: https://app.aikido.dev/queue?issue_id_filter=33654896
