### PR TITLE
Fail the e2e suite when an ingress never becomes ready

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -172,7 +172,10 @@ func (c *Cluster) CleanupSharedResources() {
 }
 
 // WaitForIngressReady waits until the ingress controller starts routing for the given host
-// by polling GET / until a non-404/non-502 response is received.
+// by polling GET / until a non-404/non-502 response is received. It fails the test when the
+// host never starts routing: otherwise a suite keeps asserting on responses coming from an
+// ingress that was never picked up, and comparisons such as 404 == 404 pass without proving
+// anything.
 func (c *Cluster) WaitForIngressReady(t *testing.T, host string, maxRetries int, delay time.Duration) {
 	t.Helper()
 
@@ -202,7 +205,8 @@ func (c *Cluster) WaitForIngressReady(t *testing.T, host string, maxRetries int,
 		}
 		time.Sleep(delay)
 	}
-	t.Logf("[%s] ingress for host %s not ready after %d retries", c.Name, host, maxRetries)
+
+	t.Fatalf("[%s] ingress for host %s not ready after %d retries", c.Name, host, maxRetries)
 }
 
 // MakeRequest makes an HTTP request to this cluster's ingress controller.


### PR DESCRIPTION
## Description

`WaitForIngressReady` only emitted a `t.Logf` when it gave up, so it could never fail a suite. When an Ingress was not picked up by either controller, the tests kept running and asserted on whatever came back — typically a 404 on both sides. A parity assertion such as `assert.Equal(nginxResp.StatusCode, traefikResp.StatusCode)` then compared `404 == 404`: green suite, zero information.

This makes the helper fail the test when the host never starts routing. Spotted by @sdelicata while reviewing #36.

## Verification

Full e2e suite (`TRAEFIK_IMAGE=traefik/traefik:pr13708`, an image built from traefik/traefik#13708), before and after the change:

- 29 suites pass, identical in both runs.
- The 3 remaining failures are the documented pre-existing behaviour gaps, unchanged: `TestRewriteTargetSuite/TestFullPathRewriteWithRegexPath`, `TestSessionAffinitySuite/TestExtendedCookieDomain`, `TestSSLPassthroughSuite/TestSSLPassthroughCertificateWithAnnotations`.
- Zero readiness timeouts across the 309 call sites, so no suite relied on the lenient behaviour and no call site needed an opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7Ehn1NqS6mMK1P7sHSs4s