### PR TITLE
fix: correct annotation catalog against Traefik v3.7

### DIFF
--- a/pkg/analyzer/report.go
+++ b/pkg/analyzer/report.go
@@ -21,35 +21,50 @@ const (
 )
 
 // knownUnsupportedAnnotations is the set of NGINX ingress controller annotations
-// that are explicitly documented as unsupported by Traefik v3.7.
+// that Traefik v3.7 does not honor: either explicitly documented as unsupported,
+// or parsed nowhere and silently ignored by the ingress-nginx provider.
 // An annotation in this set is known to the tool but has no Traefik equivalent.
 // Annotations that are in neither this set nor supportedAnnotations are "unknown"
 // to the tool and may be typos, custom extensions, or annotations not yet cataloged.
 var knownUnsupportedAnnotations = map[string]struct{}{
 	// Authentication.
-	"nginx.ingress.kubernetes.io/auth-tls-error-page":       {},
-	"nginx.ingress.kubernetes.io/auth-tls-match-cn":         {},
-	"nginx.ingress.kubernetes.io/auth-cache-key":            {},
-	"nginx.ingress.kubernetes.io/auth-cache-duration":       {},
-	"nginx.ingress.kubernetes.io/auth-keepalive":            {},
-	"nginx.ingress.kubernetes.io/auth-keepalive-share-vars": {},
-	"nginx.ingress.kubernetes.io/auth-keepalive-requests":   {},
-	"nginx.ingress.kubernetes.io/auth-keepalive-timeout":    {},
-	"nginx.ingress.kubernetes.io/auth-proxy-set-headers":    {},
-	"nginx.ingress.kubernetes.io/enable-global-auth":        {},
+	"nginx.ingress.kubernetes.io/auth-tls-error-page":        {},
+	"nginx.ingress.kubernetes.io/auth-tls-match-cn":          {},
+	"nginx.ingress.kubernetes.io/auth-cache-key":             {},
+	"nginx.ingress.kubernetes.io/auth-cache-duration":        {},
+	"nginx.ingress.kubernetes.io/auth-keepalive":             {},
+	"nginx.ingress.kubernetes.io/auth-keepalive-share-vars":  {},
+	"nginx.ingress.kubernetes.io/auth-keepalive-requests":    {},
+	"nginx.ingress.kubernetes.io/auth-keepalive-timeout":     {},
+	"nginx.ingress.kubernetes.io/auth-proxy-set-headers":     {},
+	"nginx.ingress.kubernetes.io/auth-always-set-cookie":     {},
+	"nginx.ingress.kubernetes.io/auth-request-redirect":      {},
+	"nginx.ingress.kubernetes.io/auth-signin-redirect-param": {},
+	// Traefik relies on the Go standard library for client certificate verification,
+	// which has no configurable chain depth limit.
+	"nginx.ingress.kubernetes.io/auth-tls-verify-depth": {},
 	// Error handling.
 	"nginx.ingress.kubernetes.io/disable-proxy-intercept-errors": {},
 	// Rate limiting.
 	"nginx.ingress.kubernetes.io/limit-rate-after":                {},
 	"nginx.ingress.kubernetes.io/limit-rate":                      {},
 	"nginx.ingress.kubernetes.io/limit-whitelist":                 {},
-	"nginx.ingress.kubernetes.io/limit-connections":               {},
 	"nginx.ingress.kubernetes.io/global-rate-limit":               {},
 	"nginx.ingress.kubernetes.io/global-rate-limit-window":        {},
 	"nginx.ingress.kubernetes.io/global-rate-limit-key":           {},
 	"nginx.ingress.kubernetes.io/global-rate-limit-ignored-cidrs": {},
 	// Path handling.
 	"nginx.ingress.kubernetes.io/preserve-trailing-slash": {},
+	// Load balancing.
+	// Traefik silently ignores these: the load balancing strategy is not configurable
+	// through the ingress-nginx provider, and upstream-hash-by has no subset support.
+	"nginx.ingress.kubernetes.io/load-balance":                 {},
+	"nginx.ingress.kubernetes.io/upstream-hash-by-subset":      {},
+	"nginx.ingress.kubernetes.io/upstream-hash-by-subset-size": {},
+	// Buffering.
+	"nginx.ingress.kubernetes.io/proxy-busy-buffers-size": {},
+	// HTTP/2.
+	"nginx.ingress.kubernetes.io/http2-push-preload": {},
 	// Proxy / backend.
 	"nginx.ingress.kubernetes.io/proxy-cookie-domain": {},
 	"nginx.ingress.kubernetes.io/proxy-cookie-path":   {},
@@ -65,6 +80,8 @@ var knownUnsupportedAnnotations = map[string]struct{}{
 	"nginx.ingress.kubernetes.io/satisfy":               {},
 	"nginx.ingress.kubernetes.io/denylist-source-range": {},
 	// Session affinity.
+	// Traefik only implements the persistent affinity mode.
+	"nginx.ingress.kubernetes.io/affinity-mode":                            {},
 	"nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none": {},
 	"nginx.ingress.kubernetes.io/session-cookie-change-on-failure":         {},
 	// TLS / SSL (ingress).
@@ -93,12 +110,13 @@ var supportedAnnotations = map[string]string{
 	"nginx.ingress.kubernetes.io/auth-secret":      "v3.6",
 	"nginx.ingress.kubernetes.io/auth-realm":       "v3.6",
 	"nginx.ingress.kubernetes.io/auth-secret-type": "v3.6",
-	"nginx.ingress.kubernetes.io/auth-method":      "v3.6",
+	"nginx.ingress.kubernetes.io/auth-method":      "v3.7",
 	// Forward authentication.
 	"nginx.ingress.kubernetes.io/auth-url":              "v3.6",
 	"nginx.ingress.kubernetes.io/auth-response-headers": "v3.6",
 	"nginx.ingress.kubernetes.io/auth-signin":           "v3.7",
 	"nginx.ingress.kubernetes.io/auth-snippet":          "v3.7",
+	"nginx.ingress.kubernetes.io/enable-global-auth":    "v3.7",
 	// Client TLS authentication.
 	"nginx.ingress.kubernetes.io/auth-tls-secret":                       "v3.7",
 	"nginx.ingress.kubernetes.io/auth-tls-verify-client":                "v3.7",
@@ -170,8 +188,12 @@ var supportedAnnotations = map[string]string{
 	"nginx.ingress.kubernetes.io/proxy-buffers-number":     "v3.7",
 	"nginx.ingress.kubernetes.io/proxy-max-temp-file-size": "v3.7",
 	// Rate limiting.
-	"nginx.ingress.kubernetes.io/limit-rpm": "v3.7",
-	"nginx.ingress.kubernetes.io/limit-rps": "v3.7",
+	"nginx.ingress.kubernetes.io/limit-rpm":              "v3.7",
+	"nginx.ingress.kubernetes.io/limit-rps":              "v3.7",
+	"nginx.ingress.kubernetes.io/limit-burst-multiplier": "v3.7",
+	"nginx.ingress.kubernetes.io/limit-connections":      "v3.7",
+	// Observability.
+	"nginx.ingress.kubernetes.io/enable-access-log": "v3.7",
 	// Server alias.
 	"nginx.ingress.kubernetes.io/server-alias": "v3.7",
 	// Upstream hash.

--- a/pkg/analyzer/report_test.go
+++ b/pkg/analyzer/report_test.go
@@ -132,13 +132,13 @@ func TestComputeIngressReport(t *testing.T) {
 			name: "mix of supported, known-unsupported, and unknown annotations",
 			annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/ssl-redirect":         "true",
-				"nginx.ingress.kubernetes.io/limit-connections":    "10",
+				"nginx.ingress.kubernetes.io/limit-rate":           "10",
 				"nginx.ingress.kubernetes.io/totally-unknown-flag": "true",
 			},
 			wantSupported: []AnnotationInfo{
 				{Name: "nginx.ingress.kubernetes.io/ssl-redirect", Version: "v3.6"},
 			},
-			wantUnsupported:        []string{"nginx.ingress.kubernetes.io/limit-connections"},
+			wantUnsupported:        []string{"nginx.ingress.kubernetes.io/limit-rate"},
 			wantUnknown:            []string{"nginx.ingress.kubernetes.io/totally-unknown-flag"},
 			wantHasNginxAnnotation: true,
 		},
@@ -146,11 +146,11 @@ func TestComputeIngressReport(t *testing.T) {
 			name: "only known-unsupported annotations",
 			annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/denylist-source-range": "192.0.2.0/24",
-				"nginx.ingress.kubernetes.io/limit-connections":     "10",
+				"nginx.ingress.kubernetes.io/limit-rate":            "10",
 			},
 			wantUnsupported: []string{
 				"nginx.ingress.kubernetes.io/denylist-source-range",
-				"nginx.ingress.kubernetes.io/limit-connections",
+				"nginx.ingress.kubernetes.io/limit-rate",
 			},
 			wantHasNginxAnnotation: true,
 		},
@@ -160,6 +160,72 @@ func TestComputeIngressReport(t *testing.T) {
 				"nginx.ingress.kubernetes.io/does-not-exist": "true",
 			},
 			wantUnknown:            []string{"nginx.ingress.kubernetes.io/does-not-exist"},
+			wantHasNginxAnnotation: true,
+		},
+		{
+			name: "rate limiting annotations are supported since v3.7",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/limit-rps":              "10",
+				"nginx.ingress.kubernetes.io/limit-rpm":              "60",
+				"nginx.ingress.kubernetes.io/limit-burst-multiplier": "3",
+				"nginx.ingress.kubernetes.io/limit-connections":      "5",
+			},
+			wantSupported: []AnnotationInfo{
+				{Name: "nginx.ingress.kubernetes.io/limit-burst-multiplier", Version: "v3.7"},
+				{Name: "nginx.ingress.kubernetes.io/limit-connections", Version: "v3.7"},
+				{Name: "nginx.ingress.kubernetes.io/limit-rpm", Version: "v3.7"},
+				{Name: "nginx.ingress.kubernetes.io/limit-rps", Version: "v3.7"},
+			},
+			wantHasNginxAnnotation: true,
+		},
+		{
+			name: "access log and global auth annotations are supported since v3.7",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/enable-access-log":  "false",
+				"nginx.ingress.kubernetes.io/enable-global-auth": "false",
+				"nginx.ingress.kubernetes.io/auth-method":        "GET",
+			},
+			wantSupported: []AnnotationInfo{
+				{Name: "nginx.ingress.kubernetes.io/auth-method", Version: "v3.7"},
+				{Name: "nginx.ingress.kubernetes.io/enable-access-log", Version: "v3.7"},
+				{Name: "nginx.ingress.kubernetes.io/enable-global-auth", Version: "v3.7"},
+			},
+			wantHasNginxAnnotation: true,
+		},
+		{
+			name: "annotations Traefik silently ignores are known-unsupported, not unknown",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/affinity-mode":                "balanced",
+				"nginx.ingress.kubernetes.io/auth-tls-verify-depth":        "2",
+				"nginx.ingress.kubernetes.io/http2-push-preload":           "true",
+				"nginx.ingress.kubernetes.io/load-balance":                 "ewma",
+				"nginx.ingress.kubernetes.io/proxy-busy-buffers-size":      "8k",
+				"nginx.ingress.kubernetes.io/upstream-hash-by-subset":      "true",
+				"nginx.ingress.kubernetes.io/upstream-hash-by-subset-size": "3",
+			},
+			wantUnsupported: []string{
+				"nginx.ingress.kubernetes.io/affinity-mode",
+				"nginx.ingress.kubernetes.io/auth-tls-verify-depth",
+				"nginx.ingress.kubernetes.io/http2-push-preload",
+				"nginx.ingress.kubernetes.io/load-balance",
+				"nginx.ingress.kubernetes.io/proxy-busy-buffers-size",
+				"nginx.ingress.kubernetes.io/upstream-hash-by-subset",
+				"nginx.ingress.kubernetes.io/upstream-hash-by-subset-size",
+			},
+			wantHasNginxAnnotation: true,
+		},
+		{
+			name: "forward auth cookie and redirect annotations are known-unsupported",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/auth-always-set-cookie":     "true",
+				"nginx.ingress.kubernetes.io/auth-request-redirect":      "/login",
+				"nginx.ingress.kubernetes.io/auth-signin-redirect-param": "rd",
+			},
+			wantUnsupported: []string{
+				"nginx.ingress.kubernetes.io/auth-always-set-cookie",
+				"nginx.ingress.kubernetes.io/auth-request-redirect",
+				"nginx.ingress.kubernetes.io/auth-signin-redirect-param",
+			},
 			wantHasNginxAnnotation: true,
 		},
 		{
@@ -270,7 +336,7 @@ func TestComputeReport_AnnotationClassification(t *testing.T) {
 		}),
 		// Known-unsupported annotation.
 		makeIngress("known-unsupported", map[string]string{
-			"nginx.ingress.kubernetes.io/limit-connections": "10",
+			"nginx.ingress.kubernetes.io/limit-rate": "10",
 		}),
 		// Unknown annotation.
 		makeIngress("unknown", map[string]string{
@@ -278,7 +344,7 @@ func TestComputeReport_AnnotationClassification(t *testing.T) {
 		}),
 		// Mix of unsupported and unknown.
 		makeIngress("mixed", map[string]string{
-			"nginx.ingress.kubernetes.io/limit-connections":  "10",
+			"nginx.ingress.kubernetes.io/limit-rate":         "10",
 			"nginx.ingress.kubernetes.io/totally-made-up":    "true",
 			"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
 		}),
@@ -299,7 +365,7 @@ func TestComputeReport_AnnotationClassification(t *testing.T) {
 
 	// Known-unsupported annotation frequencies.
 	assert.Equal(t, map[string]int{
-		"nginx.ingress.kubernetes.io/limit-connections": 2,
+		"nginx.ingress.kubernetes.io/limit-rate": 2,
 	}, report.UnsupportedIngressAnnotations)
 
 	// Verify individual ingress reports carry the right buckets.
@@ -309,7 +375,7 @@ func TestComputeReport_AnnotationClassification(t *testing.T) {
 	}
 
 	knownUnsupportedReport := byName["known-unsupported"]
-	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/limit-connections"}, knownUnsupportedReport.UnsupportedAnnotations)
+	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/limit-rate"}, knownUnsupportedReport.UnsupportedAnnotations)
 	assert.Empty(t, knownUnsupportedReport.UnknownAnnotations)
 
 	unknownReport := byName["unknown"]
@@ -317,7 +383,7 @@ func TestComputeReport_AnnotationClassification(t *testing.T) {
 	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/totally-made-up"}, unknownReport.UnknownAnnotations)
 
 	mixedReport := byName["mixed"]
-	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/limit-connections"}, mixedReport.UnsupportedAnnotations)
+	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/limit-rate"}, mixedReport.UnsupportedAnnotations)
 	assert.Equal(t, []string{"nginx.ingress.kubernetes.io/totally-made-up"}, mixedReport.UnknownAnnotations)
 	assert.Len(t, mixedReport.SupportedAnnotations, 1)
 }

--- a/pkg/analyzer/testdata/11-ingress-with-rate-limiting.yml
+++ b/pkg/analyzer/testdata/11-ingress-with-rate-limiting.yml
@@ -8,6 +8,8 @@ metadata:
     # Rate limiting annotations - Supported since Traefik v3.7
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-rps: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+    nginx.ingress.kubernetes.io/limit-connections: "5"
     # Connection proxy header - NOT supported by Traefik
     nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"
 spec:

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -33,7 +33,7 @@ func mixedReport() analyzer.Report {
 		UnsupportedIngressCount:      2,
 		UnsupportedIngressPercentage: 50.0,
 		UnsupportedIngressAnnotations: map[string]int{
-			"nginx.ingress.kubernetes.io/limit-connections": 2,
+			"nginx.ingress.kubernetes.io/limit-rate": 2,
 		},
 		UnknownIngressAnnotations: map[string]int{
 			"nginx.ingress.kubernetes.io/totally-made-up": 1,
@@ -43,13 +43,13 @@ func mixedReport() analyzer.Report {
 				Name:                   "api",
 				Namespace:              "prod",
 				IngressClassName:       "nginx",
-				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-connections"},
+				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-rate"},
 			},
 			{
 				Name:                   "web",
 				Namespace:              "prod",
 				IngressClassName:       "nginx",
-				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-connections"},
+				UnsupportedAnnotations: []string{"nginx.ingress.kubernetes.io/limit-rate"},
 				UnknownAnnotations:     []string{"nginx.ingress.kubernetes.io/totally-made-up"},
 			},
 		},

--- a/pkg/render/testdata/mixed.full.md
+++ b/pkg/render/testdata/mixed.full.md
@@ -23,12 +23,12 @@ Hash: `abc123def456`
 
 | Annotation | Count | Kind |
 |---|---|---|
-| `nginx.ingress.kubernetes.io/limit-connections` | 2 | unsupported |
+| `nginx.ingress.kubernetes.io/limit-rate` | 2 | unsupported |
 | `nginx.ingress.kubernetes.io/totally-made-up` | 1 | unknown |
 
 ## Ingresses needing manual work
 
 | Namespace | Name | Class | Annotations to fix |
 |---|---|---|---|
-| prod | api | nginx | nginx.ingress.kubernetes.io/limit-connections |
-| prod | web | nginx | nginx.ingress.kubernetes.io/limit-connections, nginx.ingress.kubernetes.io/totally-made-up |
+| prod | api | nginx | nginx.ingress.kubernetes.io/limit-rate |
+| prod | web | nginx | nginx.ingress.kubernetes.io/limit-rate, nginx.ingress.kubernetes.io/totally-made-up |

--- a/pkg/render/testdata/mixed.json
+++ b/pkg/render/testdata/mixed.json
@@ -15,7 +15,7 @@
   "unsupportedIngressCount": 2,
   "unsupportedIngressPercentage": 50,
   "unsupportedIngressAnnotations": {
-    "nginx.ingress.kubernetes.io/limit-connections": 2
+    "nginx.ingress.kubernetes.io/limit-rate": 2
   },
   "unknownIngressAnnotations": {
     "nginx.ingress.kubernetes.io/totally-made-up": 1
@@ -26,7 +26,7 @@
       "namespace": "prod",
       "ingressClassName": "nginx",
       "unsupportedAnnotations": [
-        "nginx.ingress.kubernetes.io/limit-connections"
+        "nginx.ingress.kubernetes.io/limit-rate"
       ]
     },
     {
@@ -34,7 +34,7 @@
       "namespace": "prod",
       "ingressClassName": "nginx",
       "unsupportedAnnotations": [
-        "nginx.ingress.kubernetes.io/limit-connections"
+        "nginx.ingress.kubernetes.io/limit-rate"
       ],
       "unknownAnnotations": [
         "nginx.ingress.kubernetes.io/totally-made-up"

--- a/pkg/render/testdata/mixed.summary.md
+++ b/pkg/render/testdata/mixed.summary.md
@@ -23,5 +23,5 @@ Hash: `abc123def456`
 
 | Annotation | Count | Kind |
 |---|---|---|
-| `nginx.ingress.kubernetes.io/limit-connections` | 2 | unsupported |
+| `nginx.ingress.kubernetes.io/limit-rate` | 2 | unsupported |
 | `nginx.ingress.kubernetes.io/totally-made-up` | 1 | unknown |

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ The Ingress NGINX Migration checks for compatibility with common Ingress NGINX C
 - IP allowlisting (`whitelist-source-range`, `allowlist-source-range`)
 - Custom headers (`custom-headers`, `upstream-vhost`)
 - Buffering (`proxy-request-buffering`, `proxy-body-size`, `proxy-buffering`, etc.)
+- Rate limiting (`limit-rps`, `limit-rpm`, `limit-burst-multiplier`, `limit-connections`)
+- Observability (`enable-access-log`)
 - ModSecurity (`enable-modsecurity`, `enable-owasp-core-rules`, `modsecurity-transaction-id`, `modsecurity-snippet`) — Traefik Hub only
 
 For a complete list of supported annotations and their Traefik equivalents, see the [Ingress NGINX Annotations table](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support) in the Traefik documentation.


### PR DESCRIPTION
Fixes #37

## What

`nginx.ingress.kubernetes.io/limit-burst-multiplier` was present in neither `supportedAnnotations` nor `knownUnsupportedAnnotations`, so it fell into the "unknown" bucket and marked the Ingress as needing manual migration.

Rather than adding that one entry, this audits the whole catalog against three sources:

- the Traefik ingress-nginx provider (`pkg/provider/kubernetes/ingress-nginx/annotations.go` at `v3.6.23`, `v3.7.0`, `v3.7.13` and `master`),
- the [Traefik ingress-nginx routing documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support),
- the upstream ingress-nginx annotation reference.

`master` and `v3.7.13` have the same annotation set, so no post-v3.7 entries were needed.

## Marked supported since v3.7

Each one verified as actually honored by the provider, not merely parsed into `IngressConfig`:

| Annotation | Note |
| --- | --- |
| `limit-burst-multiplier` | new — the issue |
| `limit-connections` | was known-unsupported; builds an `InFlightReq` middleware |
| `enable-global-auth` | was known-unsupported; honored in `buildForwardAuth` |
| `enable-access-log` | new |

## Version fix

`auth-method` was mapped to `v3.6` but is absent from the v3.6 provider. Corrected to `v3.7` — it was skewing the version classification of any Ingress using it.

## Newly cataloged as known-unsupported

These are parsed nowhere by the provider and silently ignored: `affinity-mode`, `auth-tls-verify-depth`, `load-balance`, `upstream-hash-by-subset`, `upstream-hash-by-subset-size`, `proxy-busy-buffers-size`, `http2-push-preload`, `auth-always-set-cookie`, `auth-request-redirect`, `auth-signin-redirect-param`.

They already counted as unsupported through the unknown bucket, so the compatibility numbers do not move — they are now reported as known gaps rather than as possible typos or custom extensions. With these added, every annotation documented upstream is cataloged.

The `knownUnsupportedAnnotations` doc comment is updated to cover both cases (documented-unsupported and silently-ignored).

## Not changed

The ModSecurity annotations stay mapped to `Traefik Hub v3.20` even though the Traefik docs list them under Unsupported — that table is about Traefik OSS, and Hub supports them.

## Tests

The existing tests used `limit-connections` as their known-unsupported fixture; switched to `limit-rate`, with the render golden files regenerated. Four table cases added covering the rate-limiting set, the access-log/global-auth/auth-method versions, and both groups of newly cataloged unsupported annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
